### PR TITLE
Adding an error for missing keys, ft. other minor fixes

### DIFF
--- a/R/batch.R
+++ b/R/batch.R
@@ -68,6 +68,7 @@ run_the_batches <- function(..., body_fn, trycatch, stop, verbose) {
 default_strategy <- function(..., batch_fn, keys, size, verbose) {
   args <- match.call(call = substitute(batch_fn(...)), definition = batch_fn)
   keys <- clean_keys(args, keys)
+  if (length(keys) == 0) stop('Bad keys - no batched key matches keys passed.')
   args <- cache_functions(args, keys, batch_fn)
   where_the_inputs_at <- find_inputs(args, keys) 
   if (length(where_the_inputs_at) == 0) return(NULL)

--- a/inst/tests/test-batch.R
+++ b/inst/tests/test-batch.R
@@ -5,6 +5,7 @@ record_first_arg <- list()
 batched_toupper <- batch(toupper, 'x',
   combination_strategy = paste, size = 1, verbose = FALSE)
 batched_identity <- batch(identity, 'x', combination_strategy = c, size = 1, verbose = FALSE)
+reverse <- function(x, y) c(y, x)
 
 
 check_for_batch_length_of <- function(len) {
@@ -31,8 +32,13 @@ test_that('it can recombine', {
   expect_equal('HI HELLO HOW ARE YOU', o)
 })
 
+test_that('it errors with no matching keys', {
+  batched_reverse <- batch(reverse, 'w',
+    combination_strategy = c, size = 1, verbose = FALSE)
+  expect_error(batched_reverse(c(1, 2, 3), c(4, 5, 6)), 'Bad keys')
+})
+
 test_that('it can batch twice by two keys', {
-  reverse <- function(x, y) c(y, x)
   batched_reverse <- batch(reverse, c('x', 'y'),
     combination_strategy = c, size = 1, verbose = FALSE)
   o <- batched_reverse(c(1, 2, 3), c(4, 5, 6))


### PR DESCRIPTION
- Added test coverage for batching batched functions.
- added an error if none of the keys `batch` is called with are present upon calling the batched function.
- Cleaned up `find_in_stack`.
