### PR TITLE
adding `key` argument to `batch` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,10 +20,9 @@ Suggests:
     knitr,
     microbenchmark,
     progress,
-Remotes:
-    robertzk/rocco,
+Remotes: robertzk/rocco,
     gaborcsardi/progress,
     peterhurford/checkr
 License: MIT + file LICENSE
 LazyData: true
-RoxygenNote: 5.0.1.9000
+RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: batchman
 Title: A wrapper for R methods to run them in arbitrary batches
-Version: 1.3.0.9005
+Version: 1.3.0.9006
 Author: Peter Hurford <peter@peterhurford.com>
 Maintainer: Peter Hurford <peter@peterhurford.com>
 Authors@R: person("Peter", "Hurford", email = "peter@peterhurford.com", role = c("aut", "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## v1.3.0.9006
+
+* Add a `key` argument to `batch`, since fuzzy matching works differently in later R versions.
+
 ## v1.3.0.9005
 
 * Swapped out the progress bar for another R package.

--- a/R/batch.R
+++ b/R/batch.R
@@ -32,6 +32,7 @@ batches <- structure(list(), class = "no_batches")
 #' @param parallel logical. Use parallel::mclapply to execute your batches. Incompatible with retry.
 #' @param ncores integer. Number of cores to use if parallel is set to true. Notice that it doesn't
 #'   work on windows.
+#' @param key vector. Same as /code{keys}.
 #' @return a batched version of the passed function.
 #' @examples
 #'   batched_identity <- batch(identity, "x", combination_strategy = c, size = 10)

--- a/R/batch.R
+++ b/R/batch.R
@@ -55,7 +55,9 @@ batch <- checkr::ensure(
     combination_strategy = batchman::combine, size = 50, trycatch = FALSE,
     batchman.verbose = isTRUE(interactive()), stop = FALSE,
     retry = 0, sleep = 0, ncores = parallel::detectCores(),
-    parallel = FALSE) {
+    parallel = FALSE, key) {
+    ## newer versions of R no longer fuzzy matches arguments
+    if (missing(keys)) { keys <- key }
     ## Parallellized code will behave oddly if some of the code stops for an
     ## error, so it's best not to do it.
     if (isTRUE(parallel) && isTRUE(trycatch)) {

--- a/R/batch.R
+++ b/R/batch.R
@@ -57,7 +57,7 @@ batch <- checkr::ensure(
     retry = 0, sleep = 0, ncores = parallel::detectCores(),
     parallel = FALSE, key) {
     ## newer versions of R don't fuzzy match arguments the same way
-    if (missing(keys)) { keys <- key }
+    if (missing(keys) && !missing(key)) { keys <- key }
     ## Parallellized code will behave oddly if some of the code stops for an
     ## error, so it's best not to do it.
     if (isTRUE(parallel) && isTRUE(trycatch)) {

--- a/R/batch.R
+++ b/R/batch.R
@@ -56,7 +56,7 @@ batch <- checkr::ensure(
     batchman.verbose = isTRUE(interactive()), stop = FALSE,
     retry = 0, sleep = 0, ncores = parallel::detectCores(),
     parallel = FALSE, key) {
-    ## newer versions of R no longer fuzzy matches arguments
+    ## newer versions of R don't fuzzy match arguments the same way
     if (missing(keys)) { keys <- key }
     ## Parallellized code will behave oddly if some of the code stops for an
     ## error, so it's best not to do it.

--- a/man/batch.Rd
+++ b/man/batch.Rd
@@ -7,7 +7,7 @@
 batch(batch_fn, keys, splitting_strategy = NULL,
   combination_strategy = batchman::combine, size = 50, trycatch = FALSE,
   batchman.verbose = isTRUE(interactive()), stop = FALSE, retry = 0,
-  sleep = 0, ncores = parallel::detectCores(), parallel = FALSE)
+  sleep = 0, ncores = parallel::detectCores(), parallel = FALSE, key)
 }
 \arguments{
 \item{batch_fn}{function. The method to batch over.}
@@ -38,6 +38,8 @@ Can be used to store and retrieve partial progress on an error.}
 work on windows.}
 
 \item{parallel}{logical. Use parallel::mclapply to execute your batches. Incompatible with retry.}
+
+\item{key}{vector. Same as /code{keys}.}
 }
 \value{
 a batched version of the passed function.


### PR DESCRIPTION
Ran into an error while installing a package that called `batch` with a `key = "mykey"` instead of `keys = "mykey"`. Seems like this error was due to different argument matching logic in newer R versions?

@robertzk 